### PR TITLE
Add schema metadata to computables

### DIFF
--- a/coper/Add.py
+++ b/coper/Add.py
@@ -1,6 +1,36 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class AddInput(BaseModel):
+    """Input model for :class:`Add`."""
+
+    x: float = Field(..., description="First operand")
+    y: float = Field(..., description="Second operand")
+
+
+class AddOutput(BaseModel):
+    """Output model for :class:`Add`."""
+
+    result: float = Field(..., description="Sum of ``x`` and ``y``")
 
 
 class Add(Computable):
-    def compute(self, x, y):
+    """Add two numbers."""
+
+    input_schema = AddInput
+    output_schema = AddOutput
+    description = "Return the sum of two numbers"
+
+    def compute(self, x: float, y: float) -> float:
+        """Return the sum of ``x`` and ``y``.
+
+        Args:
+            x: First operand.
+            y: Second operand.
+
+        Returns:
+            The calculated sum.
+        """
+
         return x + y

--- a/coper/BitwiseAnd.py
+++ b/coper/BitwiseAnd.py
@@ -1,6 +1,36 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class BitwiseAndInput(BaseModel):
+    """Input model for :class:`BitwiseAnd`."""
+
+    x: int = Field(..., description="Left operand")
+    y: int = Field(..., description="Right operand")
+
+
+class BitwiseAndOutput(BaseModel):
+    """Output model for :class:`BitwiseAnd`."""
+
+    result: int = Field(..., description="Result of ``x & y``")
 
 
 class BitwiseAnd(Computable):
-    def compute(self, x, y):
+    """Bitwise AND operation."""
+
+    input_schema = BitwiseAndInput
+    output_schema = BitwiseAndOutput
+    description = "Return x & y"
+
+    def compute(self, x: int, y: int) -> int:
+        """Return the bitwise AND of ``x`` and ``y``.
+
+        Args:
+            x: Left operand.
+            y: Right operand.
+
+        Returns:
+            Result of the operation.
+        """
+
         return x & y

--- a/coper/BitwiseOr.py
+++ b/coper/BitwiseOr.py
@@ -1,6 +1,36 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class BitwiseOrInput(BaseModel):
+    """Input model for :class:`BitwiseOr`."""
+
+    x: int = Field(..., description="Left operand")
+    y: int = Field(..., description="Right operand")
+
+
+class BitwiseOrOutput(BaseModel):
+    """Output model for :class:`BitwiseOr`."""
+
+    result: int = Field(..., description="Result of ``x | y``")
 
 
 class BitwiseOr(Computable):
-    def compute(self, x, y):
+    """Bitwise OR operation."""
+
+    input_schema = BitwiseOrInput
+    output_schema = BitwiseOrOutput
+    description = "Return x | y"
+
+    def compute(self, x: int, y: int) -> int:
+        """Return the bitwise OR of ``x`` and ``y``.
+
+        Args:
+            x: Left operand.
+            y: Right operand.
+
+        Returns:
+            Result of the operation.
+        """
+
         return x | y

--- a/coper/BitwiseXor.py
+++ b/coper/BitwiseXor.py
@@ -1,6 +1,36 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class BitwiseXorInput(BaseModel):
+    """Input model for :class:`BitwiseXor`."""
+
+    x: int = Field(..., description="Left operand")
+    y: int = Field(..., description="Right operand")
+
+
+class BitwiseXorOutput(BaseModel):
+    """Output model for :class:`BitwiseXor`."""
+
+    result: int = Field(..., description="Result of ``x ^ y``")
 
 
 class BitwiseXor(Computable):
-    def compute(self, x, y):
+    """Bitwise XOR operation."""
+
+    input_schema = BitwiseXorInput
+    output_schema = BitwiseXorOutput
+    description = "Return x ^ y"
+
+    def compute(self, x: int, y: int) -> int:
+        """Return the bitwise XOR of ``x`` and ``y``.
+
+        Args:
+            x: Left operand.
+            y: Right operand.
+
+        Returns:
+            Result of the operation.
+        """
+
         return x ^ y

--- a/coper/Divide.py
+++ b/coper/Divide.py
@@ -1,6 +1,36 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class DivideInput(BaseModel):
+    """Input model for :class:`Divide`."""
+
+    x: float = Field(..., description="Dividend")
+    y: float = Field(..., description="Divisor")
+
+
+class DivideOutput(BaseModel):
+    """Output model for :class:`Divide`."""
+
+    result: float = Field(..., description="Quotient of ``x / y``")
 
 
 class Divide(Computable):
-    def compute(self, x, y):
+    """Division operation."""
+
+    input_schema = DivideInput
+    output_schema = DivideOutput
+    description = "Return x divided by y"
+
+    def compute(self, x: float, y: float) -> float:
+        """Return ``x`` divided by ``y``.
+
+        Args:
+            x: Dividend.
+            y: Divisor.
+
+        Returns:
+            The quotient.
+        """
+
         return x / y

--- a/coper/Embedding.py
+++ b/coper/Embedding.py
@@ -3,12 +3,29 @@ import requests
 from core.Computable import Computable
 from typing import Union, List
 from dotenv import load_dotenv
+from pydantic import BaseModel, Field
+
+
+class EmbeddingInput(BaseModel):
+    """Input model for :class:`Embedding`."""
+
+    text: Union[str, List[str]] = Field(..., description="Text or list of texts to embed")
+
+
+class EmbeddingOutput(BaseModel):
+    """Output model for :class:`Embedding`."""
+
+    vectors: Union[List[float], List[List[float]], None] = Field(
+        ..., description="Embedding result or ``None`` if failed"
+    )
 
 
 class Embedding(Computable):
-    """
-    使用embedding计算文本的嵌入向量。
-    """
+    """Generate embeddings for text."""
+
+    input_schema = EmbeddingInput
+    output_schema = EmbeddingOutput
+    description = "Compute text embeddings"
 
     def __init__(self):
         super().__init__()
@@ -20,18 +37,14 @@ class Embedding(Computable):
         self.api_key = os.getenv('EMBEDDING_API_KEY')
         self.model = os.getenv('EMBEDDING_MODEL')
     
-    def compute(self, text: Union[str, List[str]], **kwargs):
-        """
-        计算文本的嵌入向量
-        
+    def compute(self, text: Union[str, List[str]], **kwargs) -> Union[List[float], List[List[float]], None]:
+        """Return embedding vectors for the given text.
+
         Args:
-            text (Union[str, List[str]]): 输入文本，可以是单个字符串或字符串列表
-            
+            text: Input text or list of texts.
+
         Returns:
-            Union[List[float], List[List[float]], None]: 
-            - 单个文本: 返回嵌入向量列表
-            - 多个文本: 返回嵌入向量列表的列表
-            - 失败时返回 None
+            A list of float vectors or ``None`` if the request fails.
         """
         
         headers = {

--- a/coper/Equal.py
+++ b/coper/Equal.py
@@ -1,6 +1,36 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class EqualInput(BaseModel):
+    """Input model for :class:`Equal`."""
+
+    x: float = Field(..., description="Left operand")
+    y: float = Field(..., description="Right operand")
+
+
+class EqualOutput(BaseModel):
+    """Output model for :class:`Equal`."""
+
+    result: bool = Field(..., description="Result of ``x == y``")
 
 
 class Equal(Computable):
-    def compute(self, x, y):
+    """Check equality."""
+
+    input_schema = EqualInput
+    output_schema = EqualOutput
+    description = "Return True if x == y"
+
+    def compute(self, x: float, y: float) -> bool:
+        """Return ``True`` if ``x`` equals ``y``.
+
+        Args:
+            x: Left operand.
+            y: Right operand.
+
+        Returns:
+            ``True`` if operands are equal otherwise ``False``.
+        """
+
         return x == y

--- a/coper/FloorDivide.py
+++ b/coper/FloorDivide.py
@@ -1,6 +1,36 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class FloorDivideInput(BaseModel):
+    """Input model for :class:`FloorDivide`."""
+
+    x: float = Field(..., description="Dividend")
+    y: float = Field(..., description="Divisor")
+
+
+class FloorDivideOutput(BaseModel):
+    """Output model for :class:`FloorDivide`."""
+
+    result: float = Field(..., description="Result of ``x // y``")
 
 
 class FloorDivide(Computable):
-    def compute(self, x, y):
+    """Floor division."""
+
+    input_schema = FloorDivideInput
+    output_schema = FloorDivideOutput
+    description = "Return x // y"
+
+    def compute(self, x: float, y: float) -> float:
+        """Return ``x`` floor-divided by ``y``.
+
+        Args:
+            x: Dividend.
+            y: Divisor.
+
+        Returns:
+            The floor division result.
+        """
+
         return x // y

--- a/coper/Greater.py
+++ b/coper/Greater.py
@@ -1,6 +1,36 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class GreaterInput(BaseModel):
+    """Input model for :class:`Greater`."""
+
+    x: float = Field(..., description="Left operand")
+    y: float = Field(..., description="Right operand")
+
+
+class GreaterOutput(BaseModel):
+    """Output model for :class:`Greater`."""
+
+    result: bool = Field(..., description="Result of ``x > y``")
 
 
 class Greater(Computable):
-    def compute(self, x, y):
+    """Greater-than comparison."""
+
+    input_schema = GreaterInput
+    output_schema = GreaterOutput
+    description = "Return True if x > y"
+
+    def compute(self, x: float, y: float) -> bool:
+        """Return ``True`` if ``x`` is greater than ``y``.
+
+        Args:
+            x: Left operand.
+            y: Right operand.
+
+        Returns:
+            Comparison result.
+        """
+
         return x > y

--- a/coper/GreaterEqual.py
+++ b/coper/GreaterEqual.py
@@ -1,6 +1,36 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class GreaterEqualInput(BaseModel):
+    """Input model for :class:`GreaterEqual`."""
+
+    x: float = Field(..., description="Left operand")
+    y: float = Field(..., description="Right operand")
+
+
+class GreaterEqualOutput(BaseModel):
+    """Output model for :class:`GreaterEqual`."""
+
+    result: bool = Field(..., description="Result of ``x >= y``")
 
 
 class GreaterEqual(Computable):
-    def compute(self, x, y):
+    """Greater-than-or-equal comparison."""
+
+    input_schema = GreaterEqualInput
+    output_schema = GreaterEqualOutput
+    description = "Return True if x >= y"
+
+    def compute(self, x: float, y: float) -> bool:
+        """Return ``True`` if ``x`` is greater than or equal to ``y``.
+
+        Args:
+            x: Left operand.
+            y: Right operand.
+
+        Returns:
+            Comparison result.
+        """
+
         return x >= y

--- a/coper/Invert.py
+++ b/coper/Invert.py
@@ -1,6 +1,34 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class InvertInput(BaseModel):
+    """Input model for :class:`Invert`."""
+
+    x: int = Field(..., description="Value to invert")
+
+
+class InvertOutput(BaseModel):
+    """Output model for :class:`Invert`."""
+
+    result: int = Field(..., description="Bitwise inversion of ``x``")
 
 
 class Invert(Computable):
-    def compute(self, x):
+    """Bitwise inversion."""
+
+    input_schema = InvertInput
+    output_schema = InvertOutput
+    description = "Return bitwise inversion of x"
+
+    def compute(self, x: int) -> int:
+        """Return the bitwise inversion of ``x``.
+
+        Args:
+            x: Value to invert.
+
+        Returns:
+            The inverted value.
+        """
+
         return ~x

--- a/coper/LeftShift.py
+++ b/coper/LeftShift.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class LeftShiftInput(BaseModel):
+    """Input model for :class:`LeftShift`."""
+
+    x: int = Field(..., description="Value to shift")
+    y: int = Field(..., description="Number of bits")
+
+
+class LeftShiftOutput(BaseModel):
+    """Output model for :class:`LeftShift`."""
+
+    result: int = Field(..., description="Result of ``x << y``")
 
 
 class LeftShift(Computable):
-    def compute(self, x, y):
+    """Bitwise left shift."""
+
+    input_schema = LeftShiftInput
+    output_schema = LeftShiftOutput
+    description = "Return x << y"
+
+    def compute(self, x: int, y: int) -> int:
+        """Return ``x`` left-shifted by ``y`` bits."""
+
         return x << y

--- a/coper/Less.py
+++ b/coper/Less.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class LessInput(BaseModel):
+    """Input model for :class:`Less`."""
+
+    x: float = Field(..., description="Left operand")
+    y: float = Field(..., description="Right operand")
+
+
+class LessOutput(BaseModel):
+    """Output model for :class:`Less`."""
+
+    result: bool = Field(..., description="Result of ``x < y``")
 
 
 class Less(Computable):
-    def compute(self, x, y):
+    """Less-than comparison."""
+
+    input_schema = LessInput
+    output_schema = LessOutput
+    description = "Return True if x < y"
+
+    def compute(self, x: float, y: float) -> bool:
+        """Return ``True`` if ``x`` is less than ``y``."""
+
         return x < y

--- a/coper/LessEqual.py
+++ b/coper/LessEqual.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class LessEqualInput(BaseModel):
+    """Input model for :class:`LessEqual`."""
+
+    x: float = Field(..., description="Left operand")
+    y: float = Field(..., description="Right operand")
+
+
+class LessEqualOutput(BaseModel):
+    """Output model for :class:`LessEqual`."""
+
+    result: bool = Field(..., description="Result of ``x <= y``")
 
 
 class LessEqual(Computable):
-    def compute(self, x, y):
+    """Less-than-or-equal comparison."""
+
+    input_schema = LessEqualInput
+    output_schema = LessEqualOutput
+    description = "Return True if x <= y"
+
+    def compute(self, x: float, y: float) -> bool:
+        """Return ``True`` if ``x`` is less than or equal to ``y``."""
+
         return x <= y

--- a/coper/LogicalAnd.py
+++ b/coper/LogicalAnd.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class LogicalAndInput(BaseModel):
+    """Input model for :class:`LogicalAnd`."""
+
+    x: bool = Field(..., description="Left operand")
+    y: bool = Field(..., description="Right operand")
+
+
+class LogicalAndOutput(BaseModel):
+    """Output model for :class:`LogicalAnd`."""
+
+    result: bool = Field(..., description="Result of ``x and y``")
 
 
 class LogicalAnd(Computable):
-    def compute(self, x, y):
+    """Logical AND operation."""
+
+    input_schema = LogicalAndInput
+    output_schema = LogicalAndOutput
+    description = "Return x and y"
+
+    def compute(self, x: bool, y: bool) -> bool:
+        """Return logical AND of ``x`` and ``y``."""
+
         return x and y

--- a/coper/LogicalNot.py
+++ b/coper/LogicalNot.py
@@ -1,6 +1,27 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class LogicalNotInput(BaseModel):
+    """Input model for :class:`LogicalNot`."""
+
+    x: bool = Field(..., description="Value to invert")
+
+
+class LogicalNotOutput(BaseModel):
+    """Output model for :class:`LogicalNot`."""
+
+    result: bool = Field(..., description="Logical negation of ``x``")
 
 
 class LogicalNot(Computable):
-    def compute(self, x):
+    """Logical NOT operation."""
+
+    input_schema = LogicalNotInput
+    output_schema = LogicalNotOutput
+    description = "Return not x"
+
+    def compute(self, x: bool) -> bool:
+        """Return logical NOT of ``x``."""
+
         return not x

--- a/coper/LogicalOr.py
+++ b/coper/LogicalOr.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class LogicalOrInput(BaseModel):
+    """Input model for :class:`LogicalOr`."""
+
+    x: bool = Field(..., description="Left operand")
+    y: bool = Field(..., description="Right operand")
+
+
+class LogicalOrOutput(BaseModel):
+    """Output model for :class:`LogicalOr`."""
+
+    result: bool = Field(..., description="Result of ``x or y``")
 
 
 class LogicalOr(Computable):
-    def compute(self, x, y):
+    """Logical OR operation."""
+
+    input_schema = LogicalOrInput
+    output_schema = LogicalOrOutput
+    description = "Return x or y"
+
+    def compute(self, x: bool, y: bool) -> bool:
+        """Return logical OR of ``x`` and ``y``."""
+
         return x or y

--- a/coper/MinioDelete.py
+++ b/coper/MinioDelete.py
@@ -1,9 +1,29 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class MinioDeleteInput(BaseModel):
+    """Input model for :class:`MinioDelete`."""
+
+    bucket: str = Field(..., description="Target bucket name")
+    object_name: str = Field(..., description="Object key to delete")
+
+
+class MinioDeleteOutput(BaseModel):
+    """Output model for :class:`MinioDelete`."""
+
+    result: bool = Field(..., description="Deletion status")
 
 
 class MinioDelete(Computable):
     """Delete an object from a Minio bucket."""
 
-    def compute(self, bucket: str, object_name: str):
+    input_schema = MinioDeleteInput
+    output_schema = MinioDeleteOutput
+    description = "Delete a file from Minio"
+
+    def compute(self, bucket: str, object_name: str) -> bool:
+        """Delete an object from Minio and return ``True`` when done."""
+
         self.minio.remove_object(bucket, object_name)
         return True

--- a/coper/MinioRead.py
+++ b/coper/MinioRead.py
@@ -1,10 +1,30 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class MinioReadInput(BaseModel):
+    """Input model for :class:`MinioRead`."""
+
+    bucket: str = Field(..., description="Bucket name")
+    object_name: str = Field(..., description="Object key to read")
+
+
+class MinioReadOutput(BaseModel):
+    """Output model for :class:`MinioRead`."""
+
+    data: bytes = Field(..., description="Retrieved data bytes")
 
 
 class MinioRead(Computable):
     """Read data from a Minio bucket."""
 
-    def compute(self, bucket: str, object_name: str):
+    input_schema = MinioReadInput
+    output_schema = MinioReadOutput
+    description = "Read a file from Minio"
+
+    def compute(self, bucket: str, object_name: str) -> bytes:
+        """Read data from Minio and return it."""
+
         response = self.minio.get_object(bucket, object_name)
         try:
             data = response.read()

--- a/coper/MinioWrite.py
+++ b/coper/MinioWrite.py
@@ -1,12 +1,33 @@
 from io import BytesIO
 
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class MinioWriteInput(BaseModel):
+    """Input model for :class:`MinioWrite`."""
+
+    bucket: str = Field(..., description="Bucket name")
+    object_name: str = Field(..., description="Object key")
+    data: bytes | str = Field(..., description="Data to write")
+
+
+class MinioWriteOutput(BaseModel):
+    """Output model for :class:`MinioWrite`."""
+
+    result: bool = Field(..., description="Write status")
 
 
 class MinioWrite(Computable):
     """Write data to a Minio bucket."""
 
-    def compute(self, bucket: str, object_name: str, data):
+    input_schema = MinioWriteInput
+    output_schema = MinioWriteOutput
+    description = "Write a file to Minio"
+
+    def compute(self, bucket: str, object_name: str, data: bytes | str) -> bool:
+        """Write data to Minio and return ``True`` on success."""
+
         if isinstance(data, str):
             data = data.encode()
         if not isinstance(data, (bytes, bytearray)):

--- a/coper/Modulo.py
+++ b/coper/Modulo.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class ModuloInput(BaseModel):
+    """Input model for :class:`Modulo`."""
+
+    x: float = Field(..., description="Dividend")
+    y: float = Field(..., description="Divisor")
+
+
+class ModuloOutput(BaseModel):
+    """Output model for :class:`Modulo`."""
+
+    result: float = Field(..., description="Result of ``x % y``")
 
 
 class Modulo(Computable):
-    def compute(self, x, y):
+    """Modulo operation."""
+
+    input_schema = ModuloInput
+    output_schema = ModuloOutput
+    description = "Return x % y"
+
+    def compute(self, x: float, y: float) -> float:
+        """Return the remainder of ``x`` divided by ``y``."""
+
         return x % y

--- a/coper/Mul.py
+++ b/coper/Mul.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class MulInput(BaseModel):
+    """Input model for :class:`Mul`."""
+
+    x: float = Field(..., description="Left operand")
+    y: float = Field(..., description="Right operand")
+
+
+class MulOutput(BaseModel):
+    """Output model for :class:`Mul`."""
+
+    result: float = Field(..., description="Result of ``x * y``")
 
 
 class Mul(Computable):
-    def compute(self, x, y):
+    """Multiplication operation."""
+
+    input_schema = MulInput
+    output_schema = MulOutput
+    description = "Return x * y"
+
+    def compute(self, x: float, y: float) -> float:
+        """Return the product of ``x`` and ``y``."""
+
         return x * y

--- a/coper/Multiply.py
+++ b/coper/Multiply.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class MultiplyInput(BaseModel):
+    """Input model for :class:`Multiply`."""
+
+    x: float = Field(..., description="Left operand")
+    y: float = Field(..., description="Right operand")
+
+
+class MultiplyOutput(BaseModel):
+    """Output model for :class:`Multiply`."""
+
+    result: float = Field(..., description="Result of ``x * y``")
 
 
 class Multiply(Computable):
-    def compute(self, x, y):
+    """Multiply two numbers."""
+
+    input_schema = MultiplyInput
+    output_schema = MultiplyOutput
+    description = "Return x * y"
+
+    def compute(self, x: float, y: float) -> float:
+        """Return the product of ``x`` and ``y``."""
+
         return x * y

--- a/coper/Negate.py
+++ b/coper/Negate.py
@@ -1,6 +1,27 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class NegateInput(BaseModel):
+    """Input model for :class:`Negate`."""
+
+    x: float = Field(..., description="Value to negate")
+
+
+class NegateOutput(BaseModel):
+    """Output model for :class:`Negate`."""
+
+    result: float = Field(..., description="Negated value")
 
 
 class Negate(Computable):
-    def compute(self, x):
+    """Negation operation."""
+
+    input_schema = NegateInput
+    output_schema = NegateOutput
+    description = "Return -x"
+
+    def compute(self, x: float) -> float:
+        """Return the arithmetic negation of ``x``."""
+
         return -x

--- a/coper/NotEqual.py
+++ b/coper/NotEqual.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class NotEqualInput(BaseModel):
+    """Input model for :class:`NotEqual`."""
+
+    x: float = Field(..., description="Left operand")
+    y: float = Field(..., description="Right operand")
+
+
+class NotEqualOutput(BaseModel):
+    """Output model for :class:`NotEqual`."""
+
+    result: bool = Field(..., description="Result of ``x != y``")
 
 
 class NotEqual(Computable):
-    def compute(self, x, y):
+    """Inequality comparison."""
+
+    input_schema = NotEqualInput
+    output_schema = NotEqualOutput
+    description = "Return True if x != y"
+
+    def compute(self, x: float, y: float) -> bool:
+        """Return ``True`` if ``x`` is not equal to ``y``."""
+
         return x != y

--- a/coper/Power.py
+++ b/coper/Power.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class PowerInput(BaseModel):
+    """Input model for :class:`Power`."""
+
+    x: float = Field(..., description="Base value")
+    y: float = Field(..., description="Exponent")
+
+
+class PowerOutput(BaseModel):
+    """Output model for :class:`Power`."""
+
+    result: float = Field(..., description="Result of ``x ** y``")
 
 
 class Power(Computable):
-    def compute(self, x, y):
+    """Exponentiation operation."""
+
+    input_schema = PowerInput
+    output_schema = PowerOutput
+    description = "Return x ** y"
+
+    def compute(self, x: float, y: float) -> float:
+        """Return ``x`` raised to the ``y`` power."""
+
         return x ** y

--- a/coper/RightShift.py
+++ b/coper/RightShift.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class RightShiftInput(BaseModel):
+    """Input model for :class:`RightShift`."""
+
+    x: int = Field(..., description="Value to shift")
+    y: int = Field(..., description="Number of bits")
+
+
+class RightShiftOutput(BaseModel):
+    """Output model for :class:`RightShift`."""
+
+    result: int = Field(..., description="Result of ``x >> y``")
 
 
 class RightShift(Computable):
-    def compute(self, x, y):
+    """Bitwise right shift."""
+
+    input_schema = RightShiftInput
+    output_schema = RightShiftOutput
+    description = "Return x >> y"
+
+    def compute(self, x: int, y: int) -> int:
+        """Return ``x`` right-shifted by ``y`` bits."""
+
         return x >> y

--- a/coper/Service.py
+++ b/coper/Service.py
@@ -2,18 +2,38 @@ import json
 import uuid
 
 import pika
+from pydantic import BaseModel, Field
 
 from core.Computable import Computable
 
 
+class ServiceInput(BaseModel):
+    """Input model for :class:`Service`."""
+
+    args: list = Field(default_factory=list, description="Positional arguments")
+
+
+class ServiceOutput(BaseModel):
+    """Output model for :class:`Service`."""
+
+    result: object = Field(..., description="Result returned from service")
+
+
 class Service(Computable):
+    """Invoke a remote service."""
+
+    input_schema = ServiceInput
+    output_schema = ServiceOutput
+    description = "Call a registered service"
 
     def __init__(self, service_id):
         super().__init__(service_id)
         self.service_id = service_id
 
 
-    def compute(self, *args):
+    def compute(self, *args) -> object:
+        """Invoke the remote service with the provided arguments."""
+
         return_id = str(uuid.uuid4().hex)
         return_queue = f"service-response:{self.service_id}:{return_id}"
         request = {

--- a/coper/Subtract.py
+++ b/coper/Subtract.py
@@ -1,6 +1,28 @@
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class SubtractInput(BaseModel):
+    """Input model for :class:`Subtract`."""
+
+    x: float = Field(..., description="Left operand")
+    y: float = Field(..., description="Right operand")
+
+
+class SubtractOutput(BaseModel):
+    """Output model for :class:`Subtract`."""
+
+    result: float = Field(..., description="Result of ``x - y``")
 
 
 class Subtract(Computable):
-    def compute(self, x, y):
+    """Subtraction operation."""
+
+    input_schema = SubtractInput
+    output_schema = SubtractOutput
+    description = "Return x - y"
+
+    def compute(self, x: float, y: float) -> float:
+        """Return ``x`` minus ``y``."""
+
         return x - y

--- a/coper/Test.py
+++ b/coper/Test.py
@@ -1,7 +1,29 @@
 from core.Computable import Computable
 from coper.Add import Add
+from pydantic import BaseModel, Field
+
+
+class TestInput(BaseModel):
+    """Input model for :class:`Test`."""
+
+    x: float = Field(..., description="First number")
+    y: float = Field(..., description="Second number")
+
+
+class TestOutput(BaseModel):
+    """Output model for :class:`Test`."""
+
+    result: float = Field(..., description="Computed result")
 
 class Test(Computable):
-    def compute(self, x, y):
+    """Simple test operator calling :class:`Add`."""
+
+    input_schema = TestInput
+    output_schema = TestOutput
+    description = "Add two numbers twice"
+
+    def compute(self, x: float, y: float) -> float:
+        """Use :class:`Add` twice to compute ``x + y`` twice."""
+
         add = Add()
-        return add(x,y)+add(x,y)
+        return add(x, y) + add(x, y)

--- a/coper/VectorDB.py
+++ b/coper/VectorDB.py
@@ -5,6 +5,20 @@ from pymilvus import (
 )
 from typing import Optional
 from core.Computable import Computable
+from pydantic import BaseModel, Field
+
+
+class VectorDBInput(BaseModel):
+    """Input model for :class:`VectorDB`."""
+
+    function_name: str = Field(..., description="Operation type")
+    kwargs: dict = Field(default_factory=dict, description="Arguments for the operation")
+
+
+class VectorDBOutput(BaseModel):
+    """Output model for :class:`VectorDB`."""
+
+    result: object = Field(..., description="Operation result")
 
 
 class VectorDBOperations:
@@ -84,17 +98,25 @@ class VectorDBOperations:
         
 
 class VectorDB(Computable):
+    """Perform operations on Milvus vector database."""
+
+    input_schema = VectorDBInput
+    output_schema = VectorDBOutput
+    description = "Vector database utilities"
+
     def __init__(self):
         super().__init__()
         self.vector_db = VectorDBOperations()
 
-    def compute(self, function_name, **kwargs):
-        """
-        统一计算入口，通过第一个参数指定操作类型，自动路由到对应的向量数据库操作
-        
+    def compute(self, function_name: str, **kwargs) -> object:
+        """Dispatch to the underlying vector database operations.
+
         Args:
-            function_name (str): 操作类型
-            **kwargs: 各操作所需的参数
+            function_name: Name of the operation.
+            **kwargs: Parameters for that operation.
+
+        Returns:
+            The result returned by the operation.
         """
         # 操作路由字典
         operation_map = {

--- a/core/Computable.py
+++ b/core/Computable.py
@@ -7,10 +7,21 @@ from core.Context import get_context
 
 
 class Computable:
+    """算子基类。
+
+    Subclasses should implement :meth:`compute` and provide ``input_schema``,
+    ``output_schema`` and ``description`` to describe the operator. These can be
+    defined as class attributes.
     """
-    算子基类：实现 ``compute(self, *args, **kwargs)`` 即可。
-    调用时自动使用当前 Runner，上下文管理无需 await。
-    """
+
+    #: Pydantic model describing the expected inputs of this computable.
+    input_schema = None
+
+    #: Pydantic model describing the outputs of this computable.
+    output_schema = None
+
+    #: Human readable description of the computable's capability.
+    description = ""
 
     def __init__(self, *args, **kwargs):
         self.ctx = get_context()
@@ -19,6 +30,10 @@ class Computable:
         self.minio = self.ctx.minio
         self.init_args = args
         self.init_kwargs = kwargs
+        # Copy class level descriptions so each instance carries them
+        self.description = getattr(self.__class__, 'description', '')
+        self.input_schema = getattr(self.__class__, 'input_schema', None)
+        self.output_schema = getattr(self.__class__, 'output_schema', None)
 
     def __call__(self, *args, **kwargs):
         task_id = self.ctx.task


### PR DESCRIPTION
## Summary
- extend `Computable` with `input_schema`, `output_schema` and `description`
- document these for each operator in `coper`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68456794bb70832db73a8feb69b00510