### PR TITLE
fix: use context channel instead of undefined attribute

### DIFF
--- a/coper/Service.py
+++ b/coper/Service.py
@@ -26,8 +26,10 @@ class Service(Computable):
             'args': args,
             'kwargs': kwargs,
         }
-
-        self.ch.basic_publish(
+        # ``Computable`` does not provide a channel attribute. Use the channel
+        # from the current context to publish the request message.
+        channel = self.ctx.channel
+        channel.basic_publish(
             exchange='',
             routing_key=f"service.request.{self.service_id}",
             body=serialize(request)[0],

--- a/core/Service.py
+++ b/core/Service.py
@@ -47,6 +47,9 @@ class Service(Computable):
     def __init__(self, service_id):
         super().__init__()
         self.service_id = service_id
+        # Computable does not expose a RabbitMQ channel attribute. Retrieve it
+        # from the current context so ``run`` can interact with the queue.
+        self.ch = self.ctx.channel
 
     def _on_message(self, ch, method, properties, body):
         """


### PR DESCRIPTION
## Summary
- Retrieve RabbitMQ channel from context when initializing Service
- Publish service requests via context channel instead of undefined attribute

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68985ca24ecc832db82e29f09a90af6b