### PR TITLE
Add router parameter for queue routing

### DIFF
--- a/core/Context.py
+++ b/core/Context.py
@@ -21,7 +21,7 @@ class Context:
     resetting the global ContextVar.
     """
 
-    def __init__(self, task_id=None):
+    def __init__(self, task_id=None, router: str = ""):
         base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         env_path = os.path.join(base_dir, 'middleware', '.env')
         load_dotenv(dotenv_path=env_path)
@@ -52,7 +52,8 @@ class Context:
             virtual_host="/",
             credentials=credentials,
         )
-        self.queue = "runner_task_queue"
+        self.router = router
+        self.queue = f"runner_task_queue_{router}" if router else "runner_task_queue"
         self._redis = None
         self._connection = None
         self._channel = None

--- a/core/Runner.py
+++ b/core/Runner.py
@@ -142,11 +142,16 @@ class Runner:
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--router", default="", help="Router name to listen to (queue: runner_task_queue_{router})")
+    args = parser.parse_args()
+
     def run():
-        with Context():
+        with Context(router=args.router):
             runner = Runner()
             runner.start()
-
 
     mpl = []
     for _ in range(16):


### PR DESCRIPTION
## Summary
- compute queue name as `runner_task_queue_{router}` when a router is provided, falling back to `runner_task_queue`
- clarify runner CLI `--router` argument
- drop router test per review feedback

## Testing
- `python -m py_compile core/Context.py core/Runner.py`
- No tests run per user instruction


------
https://chatgpt.com/codex/tasks/task_e_68985f7fbb60832da29ae4b9dcd2cf76